### PR TITLE
Fixed CI after ddev 1.22 release.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Setup DDEV
-        uses: jonaseberle/github-action-setup-ddev@v1
+        uses: ddev/github-action-setup-ddev@v1
       - name: Install dependencies
         run: ddev composer install
       - name: Install Drupal
@@ -27,7 +27,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Setup DDEV
-        uses: jonaseberle/github-action-setup-ddev@v1
+        uses: ddev/github-action-setup-ddev@v1
       - name: Install dependencies
         run: ddev composer install
       - name: Check coding standards
@@ -40,7 +40,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Setup DDEV
-        uses: jonaseberle/github-action-setup-ddev@v1
+        uses: ddev/github-action-setup-ddev@v1
       - name: Install dependencies
         run: ddev composer install
       - name: Enable XDebug


### PR DESCRIPTION
There's is a new official github action that we should be using.
Otherwise we get an error because dba is not available anymore with 1.22.